### PR TITLE
change the type passed to display.show()

### DIFF
--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -29,11 +29,12 @@ Once you're connected, try running this code:
 from machine import *
 import framebuf
 
-fbuf = framebuf.FrameBuffer(bytearray(640 * 400 * 2), 640, 400, framebuf.RGB565)
+buf = bytearray(640 * 400 * 2)
+fbuf = framebuf.FrameBuffer(buf, 640, 400, framebuf.RGB565)
 fbuf.fill(0)
 fbuf.text('MicroPython!', 0, 0, 0xffff)
 
-machine.Display.show(fbuf)
+machine.Display.show(buf)
 ```
 ## Mobile app
 


### PR DESCRIPTION
extmod/modframebuff.c makes use of MP_REGISTER_MODULE() which does nothing on its own, but that a makemoduledefs.py script scans to generate the header declaring all the types across all modules: no header file at all!

Therefore, the types declared for the framebuf are not accessible from the reset of the C source code base.

I assume it was intended to make use of it by accessing the bytearray passed to it, which is well defined from C, and that we can use in our Display.show().

This means the API shown in the example has to be changed.