### PR TITLE
Fix MicroPython syntax for entering DFU mode

### DIFF
--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -351,9 +351,9 @@ To perform an update:
 
 1. Download the latest `monocle-vXX.XXX.XXXX.zip` package from our [GitHub releases](https://github.com/brilliantlabsAR/monocle-micropython/releases) page.
 
-1. Issue an update command over MicroPython using `import device; device.update()`. Monocle will now reboot into DFU mode.
+2. Issue an update command over MicroPython using `import update; update.micropython()`. Monocle will now reboot into DFU mode.
 
-1. Using the nRF Connect App, for [desktop](https://www.nordicsemi.com/Products/Development-tools/nrf-connect-for-desktop), [Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en&gl=US), or [iOS](https://apps.apple.com/se/app/nrf-connect-for-mobile/id1054362403), you can reconnect to Monocle, select the downloaded `.zip` file, and update to the latest version.
+3. Using the nRF Connect App, for [desktop](https://www.nordicsemi.com/Products/Development-tools/nrf-connect-for-desktop), [Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en&gl=US), or [iOS](https://apps.apple.com/se/app/nrf-connect-for-mobile/id1054362403), you can reconnect to Monocle, select the downloaded `.zip` file, and update to the latest version.
 
 ### FPGA bitstream updates
 {: .no_toc }

--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -81,18 +81,18 @@ We're gradually building our companion app along with some extra features to hel
 
 > The device class contains general information about the Monocle's hardware and firmware.
 
-| Members | Description |
-|:--------|:------------|
-| `NAME` **constant**                           | Constant which holds `'monocle'` as a **string**.
-| `mac_address()` **function**                  | Returns the 48-bit MAC address as a 17 character **string** in the format `'xx:xx:xx:xx:xx:xx'`, where each `xx` is a byte in lowercase hex format.
-| `VERSION` **constant**                        | Constant containing the firmware version as a **string**. E.g. `'monocle-firmware-v22.342.1252'`.
-| `GIT_TAG` **constant**                        | Constant containing the build git tag as a 7 character **string**.
-| `GIT_REPO` **constant**                       | Constant containing the project git repo as a **string**.
-| `battery_level()` **function**                | Returns the battery level percentage as an **integer**.
-| `reset()` **function**                        | Resets the device.
-| `reset_cause()` **function**                  | Returns the reason for the previous reset or startup state. These can be either:<br>- `'POWERED_ON'` if the device was powered on normally<br>- `'SOFTWARE_RESET'` if `device.reset()` was called<br>- `'CRASHED'` if the device had crashed.
-| `prevent_sleep(enable)`&nbsp;**function**     | Enables or disables sleeping of the device when put back into the charging case. Sleeping is enabled by default. If no argument is given. The currently set value is returned. **WARNING: Running monocle for prolonged periods may result in display burn in, as well as reduced lifetime of components.**
-| `force_sleep()` **function**                  | Puts the device to sleep. All hardware components are shut down, and Bluetooth is disconnected. Upon touching either of the touch pads, the device will wake up, and reset.
+| Members                                   | Description                                                                                                                                                                                                                                                                                                 |
+| :---------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NAME` **constant**                       | Constant which holds `'monocle'` as a **string**.                                                                                                                                                                                                                                                           |
+| `mac_address()` **function**              | Returns the 48-bit MAC address as a 17 character **string** in the format `'xx:xx:xx:xx:xx:xx'`, where each `xx` is a byte in lowercase hex format.                                                                                                                                                         |
+| `VERSION` **constant**                    | Constant containing the firmware version as a **string**. E.g. `'monocle-firmware-v22.342.1252'`.                                                                                                                                                                                                           |
+| `GIT_TAG` **constant**                    | Constant containing the build git tag as a 7 character **string**.                                                                                                                                                                                                                                          |
+| `GIT_REPO` **constant**                   | Constant containing the project git repo as a **string**.                                                                                                                                                                                                                                                   |
+| `battery_level()` **function**            | Returns the battery level percentage as an **integer**.                                                                                                                                                                                                                                                     |
+| `reset()` **function**                    | Resets the device.                                                                                                                                                                                                                                                                                          |
+| `reset_cause()` **function**              | Returns the reason for the previous reset or startup state. These can be either:<br>- `'POWERED_ON'` if the device was powered on normally<br>- `'SOFTWARE_RESET'` if `device.reset()` was called<br>- `'CRASHED'` if the device had crashed.                                                               |
+| `prevent_sleep(enable)`&nbsp;**function** | Enables or disables sleeping of the device when put back into the charging case. Sleeping is enabled by default. If no argument is given. The currently set value is returned. **WARNING: Running monocle for prolonged periods may result in display burn in, as well as reduced lifetime of components.** |
+| `force_sleep()` **function**              | Puts the device to sleep. All hardware components are shut down, and Bluetooth is disconnected. Upon touching either of the touch pads, the device will wake up, and reset.                                                                                                                                 |
 
 ---
 
@@ -100,18 +100,18 @@ We're gradually building our companion app along with some extra features to hel
 
 > The display module allows for drawing to the micro OLED display. An image can be prepared using the functions below, and then `show()` can be used to print the image to the display.
 
-| Members | Description |
-|:--------|:------------|
-| `fill(color)` **function**                   | Fills the entire display with a color. `color` should be a 24-bit RGB value such as `0xAABBCC`.
-| `pixel(x, y, color)` **function** ❌           | Draws a single pixel of color `color` at the position `x`, `y`.
-| `hline(x,y,width,color)` **function**        | Draws a horizontal line from the position `x`, `y`, with a given `width` and `color`.
-| `vline(x,y,height,color)` **function**       | Draws a vertical line from the position `x`, `y`, with a given `height` and `color`.
-| `line(x1,y1,x2,y2,color)` **function**       | Draws a straight line from the position `x1`, `y1`, to the position `x2`, `y2`, with a given `color`.
-| `text("string",x,y,color)`&nbsp;**function** | Draws text at the position `x`, `y`, with a given `color`.
-| `show()` **function**                        | Prints the populated frame buffer to the display. After this call, another series of drawing functions may be called and `show()` can be used to print the next frame.
-| `brightness(level)` **function**             | Sets the display's brightness. `level` can be 0, 1, 2, 3, or 4.
-| `WIDTH` **constant**                         | The display width in pixels. Equal to 640.
-| `HEIGHT` **constant**                        | The display height in pixels. Equal to 400.
+| Members                                      | Description                                                                                                                                                            |
+| :------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fill(color)` **function**                   | Fills the entire display with a color. `color` should be a 24-bit RGB value such as `0xAABBCC`.                                                                        |
+| `pixel(x, y, color)` **function** ❌          | Draws a single pixel of color `color` at the position `x`, `y`.                                                                                                        |
+| `hline(x,y,width,color)` **function**        | Draws a horizontal line from the position `x`, `y`, with a given `width` and `color`.                                                                                  |
+| `vline(x,y,height,color)` **function**       | Draws a vertical line from the position `x`, `y`, with a given `height` and `color`.                                                                                   |
+| `line(x1,y1,x2,y2,color)` **function**       | Draws a straight line from the position `x1`, `y1`, to the position `x2`, `y2`, with a given `color`.                                                                  |
+| `text("string",x,y,color)`&nbsp;**function** | Draws text at the position `x`, `y`, with a given `color`.                                                                                                             |
+| `show()` **function**                        | Prints the populated frame buffer to the display. After this call, another series of drawing functions may be called and `show()` can be used to print the next frame. |
+| `brightness(level)` **function**             | Sets the display's brightness. `level` can be 0, 1, 2, 3, or 4.                                                                                                        |
+| `WIDTH` **constant**                         | The display width in pixels. Equal to 640.                                                                                                                             |
+| `HEIGHT` **constant**                        | The display height in pixels. Equal to 400.                                                                                                                            |
 
 ---
 
@@ -119,15 +119,15 @@ We're gradually building our companion app along with some extra features to hel
 
 > The camera module allows for capturing images and transferring them to another device over Bluetooth.
 
-| Members | Description |
-|:--------|:------------|
-| `capture()` **function** ❌                    | Captures an image and returns it to a device over Bluetooth. See [downloading media](#downloading-media) to understand how media transfers are done.
-| `overlay(enable)` **function**               | Enables or disables an overlay of what the camera is currently seeing onto the display.
-| `output(x,y,format)`&nbsp;**function**&nbsp;❌ | Set the output resolution and format. `x` and `y` represent the output resolution in pixels. `format` can be either `RGB`, `'YUV'` or `'JPEG'`. The default output settings are `camera.output(640, 400, 'YUV')`.
-| `zoom(multiplier)` **function** ❌             | Sets the zoom level of the camera. Multiplier can be any floating point number between 1 and 8.
-| `RGB` ❌ **constant**                          | String constant which represents a RGB565 output format.
-| `YUV` ❌ **constant**                          | String constant which represents a YUV422 output format.
-| `JPEG` ❌ **constant**                         | String constant which represents a jpeg output format.
+| Members                                       | Description                                                                                                                                                                                                       |
+| :-------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `capture()` **function** ❌                    | Captures an image and returns it to a device over Bluetooth. See [downloading media](#downloading-media) to understand how media transfers are done.                                                              |
+| `overlay(enable)` **function**                | Enables or disables an overlay of what the camera is currently seeing onto the display.                                                                                                                           |
+| `output(x,y,format)`&nbsp;**function**&nbsp;❌ | Set the output resolution and format. `x` and `y` represent the output resolution in pixels. `format` can be either `RGB`, `'YUV'` or `'JPEG'`. The default output settings are `camera.output(640, 400, 'YUV')`. |
+| `zoom(multiplier)` **function** ❌             | Sets the zoom level of the camera. Multiplier can be any floating point number between 1 and 8.                                                                                                                   |
+| `RGB` ❌ **constant**                          | String constant which represents a RGB565 output format.                                                                                                                                                          |
+| `YUV` ❌ **constant**                          | String constant which represents a YUV422 output format.                                                                                                                                                          |
+| `JPEG` ❌ **constant**                         | String constant which represents a jpeg output format.                                                                                                                                                            |
 
 ---
 
@@ -135,9 +135,9 @@ We're gradually building our companion app along with some extra features to hel
 
 > The microphone module allows for capturing audio and streaming it to another device over Bluetooth.
 
-| Members | Description |
-|:--------|:------------|
-| `stream()`&nbsp;**function**&nbsp;❌ | Streams audio from the microphone to a device over Bluetooth. See [downloading media](#downloading-media) to understand how media transfers are performed.
+| Members                             | Description                                                                                                                                                |
+| :---------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stream()`&nbsp;**function**&nbsp;❌ | Streams audio from the microphone to a device over Bluetooth. See [downloading media](#downloading-media) to understand how media transfers are performed. |
 
 ---
 
@@ -145,13 +145,13 @@ We're gradually building our companion app along with some extra features to hel
 
 > The touch module allows for reacting to touch events from the capacitive touch pads on Monocle.
 
-| Members | Description |
-|:--------|:------------|
-| `callback(pad,callback)`&nbsp;**function** | Attaches a callback handler to one or both of the touch pads. If `pad` is given as `touch.BOTH`, a single callback will be used to capture both touch events. Otherwise `touch.A` or `touch.B` can be used to assign separate callback functions if desired. `callback` should be a predefined function taking one argument. This argument will equal the pad which triggered the callback. To unassign a callback, issue `touch.callback()` with `None` in the `callback` argument. To view the currently assigned callback, issue `touch.callback()` without the `callback` argument.
-| `state(pad)` **function**                  | Returns the current touch state of the touch pads. If `pad` is not specified, either `'A'`, `'B'`, `'BOTH'` or `None` will be returned depending on which pads are currently touched. If `pad` is specified, then `True` or `False` will be returned for the touch state of that pad.
-| `A` **constant**                           | String constant which represents Pad A.
-| `B` **constant**                           | String constant which represents Pad B.
-| `BOTH` **constant**                        | String constant which represents both pads.
+| Members                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :----------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `callback(pad,callback)`&nbsp;**function** | Attaches a callback handler to one or both of the touch pads. If `pad` is given as `touch.BOTH`, a single callback will be used to capture both touch events. Otherwise `touch.A` or `touch.B` can be used to assign separate callback functions if desired. `callback` should be a predefined function taking one argument. This argument will equal the pad which triggered the callback. To unassign a callback, issue `touch.callback()` with `None` in the `callback` argument. To view the currently assigned callback, issue `touch.callback()` without the `callback` argument. |
+| `state(pad)` **function**                  | Returns the current touch state of the touch pads. If `pad` is not specified, either `'A'`, `'B'`, `'BOTH'` or `None` will be returned depending on which pads are currently touched. If `pad` is specified, then `True` or `False` will be returned for the touch state of that pad.                                                                                                                                                                                                                                                                                                   |
+| `A` **constant**                           | String constant which represents Pad A.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `B` **constant**                           | String constant which represents Pad B.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `BOTH` **constant**                        | String constant which represents both pads.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 ---
 
@@ -159,12 +159,12 @@ We're gradually building our companion app along with some extra features to hel
 
 > The LED module contains functions to control the red and green LED on the front of Monocle.
 
-| Members | Description |
-|:--------|:------------|
-| `on(color)` **function**             | Illuminates an led. `color` can be either `led.RED` or `led.GREEN`.
-| `off(color)`&nbsp;**function**&nbsp; | Turns off an led. `color` can be either `led.RED` or `led.GREEN`.
-| `RED` **constant**                   | String constant which represents the red led.
-| `GREEN` **constant**                 | String constant which represents the green led.
+| Members                              | Description                                                         |
+| :----------------------------------- | :------------------------------------------------------------------ |
+| `on(color)` **function**             | Illuminates an led. `color` can be either `led.RED` or `led.GREEN`. |
+| `off(color)`&nbsp;**function**&nbsp; | Turns off an led. `color` can be either `led.RED` or `led.GREEN`.   |
+| `RED` **constant**                   | String constant which represents the red led.                       |
+| `GREEN` **constant**                 | String constant which represents the green led.                     |
 
 ---
 
@@ -172,10 +172,10 @@ We're gradually building our companion app along with some extra features to hel
 
 > The FPGA module allows for direct control of the FPGA, as well as the ability to update the bitstream.
 
-| Members | Description |
-|:--------|:------------|
-| `read(addr, n)` **function**            | Reads `n` number of bytes from the 16-bit address `addr`, and returns a **bytes object**.
-| `write(addr,bytes[])`&nbsp;**function** | Writes all bytes from a given **bytes object** `bytes[]` to the 16-bit address `addr`.
+| Members                                 | Description                                                                               |
+| :-------------------------------------- | :---------------------------------------------------------------------------------------- |
+| `read(addr, n)` **function**            | Reads `n` number of bytes from the 16-bit address `addr`, and returns a **bytes object**. |
+| `write(addr,bytes[])`&nbsp;**function** | Writes all bytes from a given **bytes object** `bytes[]` to the 16-bit address `addr`.    |
 
 ---
 
@@ -183,13 +183,13 @@ We're gradually building our companion app along with some extra features to hel
 
 > Storage can be used for reading or writing to files within the non-volatile storage. `"file"` can be any user defined string, however certain strings are reserved for special uses such as `"fpga-bitstream"` which is used to store the FPGA application.
 
-| Members | Description |
-|:--------|:------------|
-|`read("file",length,offset)`&nbsp;**function**&nbsp;❌ | Reads and returns a **bytes object** of length `length` from a file `file` within the non-volatile storage. `offset` is an optional position in bytes from the start of the file to read from.
-|`append("file", bytes[])` **function** ❌              | Appends data from a **bytes object** `bytes[]` to the end of a file within. If the file doesn't exist, then it's created.
-|`delete("file")` **function** ❌                       | Deletes a file from the storage.
-|`list()` **function** ❌                               | Lists all files within the storage.
-|`FPGA_BITSTREAM` **constant** ❌                       | A special filename which is used for storing the FPGA bitstream. It is used by the `update.fpga()` function to update the FPGA application.
+| Members                                               | Description                                                                                                                                                                                    |
+| :---------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `read("file",length,offset)`&nbsp;**function**&nbsp;❌ | Reads and returns a **bytes object** of length `length` from a file `file` within the non-volatile storage. `offset` is an optional position in bytes from the start of the file to read from. |
+| `append("file", bytes[])` **function** ❌              | Appends data from a **bytes object** `bytes[]` to the end of a file within. If the file doesn't exist, then it's created.                                                                      |
+| `delete("file")` **function** ❌                       | Deletes a file from the storage.                                                                                                                                                               |
+| `list()` **function** ❌                               | Lists all files within the storage.                                                                                                                                                            |
+| `FPGA_BITSTREAM` **constant** ❌                       | A special filename which is used for storing the FPGA bitstream. It is used by the `update.fpga()` function to update the FPGA application.                                                    |
 
 ---
 
@@ -197,12 +197,12 @@ We're gradually building our companion app along with some extra features to hel
 
 > The `bluetooth` module can be used to transfer byte data between Monocle and the host Bluetooth device. Bytes can contain any arbitrary data, and avoids having to pollute the REPL interface with printing data out as strings. The [raw data service](#communication) is used for all communications under the `bluetooth` module.
 
-| Members | Description |
-|:--------|:------------|
-|`send(bytes[])` **function**                   | Sends data from a **bytes object** `bytes[]` over Bluetooth using the [raw data service](#communication). The length of `bytes[]` must be equal to or less than the value returned by the `bluetooth.max_length()` function.
-|`receive_callback(callback)`&nbsp;**function** | Assigns a callback to receive data over the [raw data service](#communication). `callback` must be a predefined function taking one argument. The value of the argument will be a **bytes object** `bytes[]` containing the received data. To unbind the callback, issue this function with `callback` set as `None`. If `callback` isn't given when issuing this function, the currently set callback will be returned if it is set.
-|`connected()` **function**                     | Returns `True` if the [raw data service](#communication) is connected, otherwise returns `False`.
-|`max_length()` **function**                    | Returns the maximum data size the Bluetooth host allows for single transfers.
+| Members                                        | Description                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| :--------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `send(bytes[])` **function**                   | Sends data from a **bytes object** `bytes[]` over Bluetooth using the [raw data service](#communication). The length of `bytes[]` must be equal to or less than the value returned by the `bluetooth.max_length()` function.                                                                                                                                                                                                          |
+| `receive_callback(callback)`&nbsp;**function** | Assigns a callback to receive data over the [raw data service](#communication). `callback` must be a predefined function taking one argument. The value of the argument will be a **bytes object** `bytes[]` containing the received data. To unbind the callback, issue this function with `callback` set as `None`. If `callback` isn't given when issuing this function, the currently set callback will be returned if it is set. |
+| `connected()` **function**                     | Returns `True` if the [raw data service](#communication) is connected, otherwise returns `False`.                                                                                                                                                                                                                                                                                                                                     |
+| `max_length()` **function**                    | Returns the maximum data size the Bluetooth host allows for single transfers.                                                                                                                                                                                                                                                                                                                                                         |
 
 ---
 
@@ -210,17 +210,17 @@ We're gradually building our companion app along with some extra features to hel
 
 > The time module allows for getting/setting the time and date as well as adding delays into your programs.
 
-| Members | Description |
-|:--------|:------------|
-| `time(secs)` **function**                      | Sets or gets the current system time in seconds. If `secs` is not provided, the current time is returned, otherwise the time is set according to the value of `secs`. `secs` should be referenced from midnight on the 1st of January 1970.
-| `now(epoch)` **function**                      | Returns a dictionary containing a human readable date and time. If no argument is provided, the current system time is used. If `epoch` is provided, that value will be used to generate the dictionary. The epoch should be referenced from midnight on the 1st of January 1970.
-| `zone(offset)` **function**                    | Sets or gets the time zone offset from GMT as a **string**. If `offset` is provided, the timezone is set to the new value. `offset` must be provided as a string, eg *"8:00"*, or *"-06:30"*.
-| `mktime(dict)` **function**                    | The inverse of `now()`. Converts a dictionary provided into an epoch timestamp. The returned epoch value will be referenced from midnight on the 1st of January 1970.
-| `sleep(secs)` **function**                     | Sleep for a given number of seconds.
-| `sleep_ms(msecs)` **function**                 | Sleep for a given number of milliseconds.
-| `ticks_ms()` **function**                      | Returns a timestamp in milliseconds since power on.
-| `ticks_add(ticks, delta)` **function**         | Offsets a timestamp value by a given number. Can be positive or negative.
-| `ticks_diff(ticks1,ticks2)`&nbsp;**function** | Returns the difference between two timestamps. i.e. `ticks1 - ticks2`, but takes into consideration if the numbers wrap around.
+| Members                                       | Description                                                                                                                                                                                                                                                                       |
+| :-------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `time(secs)` **function**                     | Sets or gets the current system time in seconds. If `secs` is not provided, the current time is returned, otherwise the time is set according to the value of `secs`. `secs` should be referenced from midnight on the 1st of January 1970.                                       |
+| `now(epoch)` **function**                     | Returns a dictionary containing a human readable date and time. If no argument is provided, the current system time is used. If `epoch` is provided, that value will be used to generate the dictionary. The epoch should be referenced from midnight on the 1st of January 1970. |
+| `zone(offset)` **function**                   | Sets or gets the time zone offset from GMT as a **string**. If `offset` is provided, the timezone is set to the new value. `offset` must be provided as a string, eg *"8:00"*, or *"-06:30"*.                                                                                     |
+| `mktime(dict)` **function**                   | The inverse of `now()`. Converts a dictionary provided into an epoch timestamp. The returned epoch value will be referenced from midnight on the 1st of January 1970.                                                                                                             |
+| `sleep(secs)` **function**                    | Sleep for a given number of seconds.                                                                                                                                                                                                                                              |
+| `sleep_ms(msecs)` **function**                | Sleep for a given number of milliseconds.                                                                                                                                                                                                                                         |
+| `ticks_ms()` **function**                     | Returns a timestamp in milliseconds since power on.                                                                                                                                                                                                                               |
+| `ticks_add(ticks, delta)` **function**        | Offsets a timestamp value by a given number. Can be positive or negative.                                                                                                                                                                                                         |
+| `ticks_diff(ticks1,ticks2)`&nbsp;**function** | Returns the difference between two timestamps. i.e. `ticks1 - ticks2`, but takes into consideration if the numbers wrap around.                                                                                                                                                   |
 
 ---
 
@@ -228,10 +228,10 @@ We're gradually building our companion app along with some extra features to hel
 
 > The update module allows for firmware upgrades of the MicroPython firmware, as well as the FPGA bitstream over bluetooth.
 
-| Members | Description |
-|:--------|:------------|
-| `micropython()`&nbsp;**function** | Puts the device into over-the-air device firmware update mode. The device will stay in DFU mode for 5 minutes or until an update is finished being performed. The device will then restart with an updated MicroPython firmware.
-| `fpga(url)` **function** ❌ | Downloads and reboots the FPGA with a bitstream provided from the `url`. If the update is interrupted part way through, the FPGA will no longer be running a valid application, and must be updated again. See [FPGA bitstream updates](#fpga-bitstream-updates) to understand how the update process is done.
+| Members                           | Description                                                                                                                                                                                                                                                                                                    |
+| :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `micropython()`&nbsp;**function** | Puts the device into over-the-air device firmware update mode. The device will stay in DFU mode for 5 minutes or until an update is finished being performed. The device will then restart with an updated MicroPython firmware.                                                                               |
+| `fpga(url)` **function** ❌        | Downloads and reboots the FPGA with a bitstream provided from the `url`. If the update is interrupted part way through, the FPGA will no longer be running a valid application, and must be updated again. See [FPGA bitstream updates](#fpga-bitstream-updates) to understand how the update process is done. |
 
 ---
 
@@ -336,14 +336,14 @@ Media files such as audio and images may be downloaded from the Monocle using th
 
 Due to the small payload size of Bluetooth packets, the file may be spit into many *chunks* and need to be recombined by the receiving central device. A flag at the start of each payload indicates if it is the **START**, **MIDDLE** or **END** of the file. A very small file may also be transferred using the **SMALL** flag.
 
-The first payload includes metadata about the file such as the filename (with a relevant file extension) and the file size. The sequence diagram below describes how a file is broken into several parts and the data can be recombined to construct the full file: 
+The first payload includes metadata about the file such as the filename (with a relevant file extension) and the file size. The sequence diagram below describes how a file is broken into several parts and the data can be recombined to construct the full file:
 
 ![Sequence diagram of the Monocle raw data service](/micropython/images/bluetooth-raw-data-service-sequence-diagram.svg)
 
 ### Firmware updates
 {: .no_toc }
 
-Updates of the MicroPython firmware are handled using Nordic's over-the-air device firmware update process. 
+Updates of the MicroPython firmware are handled using Nordic's over-the-air device firmware update process.
 
 To perform an update:
 
@@ -351,9 +351,9 @@ To perform an update:
 
 1. Download the latest `monocle-vXX.XXX.XXXX.zip` package from our [GitHub releases](https://github.com/brilliantlabsAR/monocle-micropython/releases) page.
 
-2. Issue an update command over MicroPython using `import update; update.micropython()`. Monocle will now reboot into DFU mode.
+1. Issue an update command over MicroPython using `import update; update.micropython()`. Monocle will now reboot into DFU mode.
 
-3. Using the nRF Connect App, for [desktop](https://www.nordicsemi.com/Products/Development-tools/nrf-connect-for-desktop), [Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en&gl=US), or [iOS](https://apps.apple.com/se/app/nrf-connect-for-mobile/id1054362403), you can reconnect to Monocle, select the downloaded `.zip` file, and update to the latest version.
+1. Using the nRF Connect App, for [desktop](https://www.nordicsemi.com/Products/Development-tools/nrf-connect-for-desktop), [Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en&gl=US), or [iOS](https://apps.apple.com/se/app/nrf-connect-for-mobile/id1054362403), you can reconnect to Monocle, select the downloaded `.zip` file, and update to the latest version.
 
 ### FPGA bitstream updates
 {: .no_toc }


### PR DESCRIPTION
Changes from device.update() to update.mciropython() syntax. 

Note that this procedure is also (correctly) documented in update.md so this section could instead be linked to that page, so there is only one place in the docs where the information is maintained / reduces chance of future changes going out of sync.