### PR TITLE
Some typo

### DIFF
--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -104,11 +104,11 @@ device.battery_level() # Returns the current battery level as a percentage
 | Members | Description |
 |:--------|:------------|
 | `brightness(level)` **function**             | Sets the display's brightness. `level` can be 0, 1, 2, 3, or 4.
-| `Text(string, fg=)` **class**                | Text with the given `string` shown with the given color [1]
-| `Rect(width, height, fg=)` **class**         | Rectangle with given width, height and color [1]
-| `Line(x1, y1, x2, y2, fg=)` **class**        | Line with given coordinates and color [1]
-| `Polygon(list, width=, fg=, bg=)` **class**  | Polygon with given fill and stroke color [1], the shape is defined by a `list` of tuples of `(x, y)` coordinates.
-| `Polyline(list, width=, fg=)` **class**      | Segmented line with given color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
+| `Text(string, color=)` **class**             | Text with the given `string` shown with the given color [1]
+| `Rect(width, height, color=)` **class**      | Rectangle with given width, height and color [1]
+| `Line(x1, y1, x2, y2, color=)` **class**     | Line with given coordinates and color [1]
+| `Polygon(list, width=, stroke=, fill=)` **class** | Polygon with given fill and stroke color [1], the shape is defined by a `list` of tuples of `(x, y)` coordinates.
+| `Polyline(list, width=, color=)` **class**   | Segmented line with given color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
 | `show(list)` **function**                    | Show a list of shapes onto the display.
 | `WIDTH` **constant**                         | The display width in pixels. Equal to 640.
 | `HEIGHT` **constant**                        | The display height in pixels. Equal to 400.
@@ -139,38 +139,31 @@ from display import *
 
 # Create a list that will contain all the thing we want to display
 list = [
-  # It has a long red horizontal rectangle that we place near the middle
-  Rect(10, 30, fg=RED).move(300, 200),
+  # It has a text message in the middle
+  Text("something").move(WIDTH//2, HEIGHT//2),
 
-  # It has a vertical line with 5 segments doing some zig-zags.
-  Polyline([(10,20), (40,40), (10,60), (40,80), (10,100), (40,120)], fg=RED),
+  # It has a long red horizontal rectangle that we place near the middle
+  Rect(100, 30, color=RED).move(300, 200),
+
+  # It has a horizontal line with 5 segments doing some zig-zags.
+  Polyline([(100,20), (200,80), (300,20), (400,80), (500,20), (600,80)], color=RED),
 
   # It has a triangle filled in yellow, moved to the top right corner.
-  Polygon([(0,0), (10,0), (5,8)], bg=YELLOW).move(WIDTH - 50, HEIGHT - 50),
+  Polygon([(0,0), (100,0), (50,80)], stroke=None, fill=YELLOW).move(50, 100),
 
   # It has a diagonal line through the whole display, bottom left to top right
-  Line(0, 0, WIDTH, HEIGHT),
-
-  # It has a text message in the middle
-  Text("something").move(WIDTH/2, HEIGHT/2),
+  Line(0, 0, WIDTH - 1, HEIGHT - 1),
 ]
 
 # Render these elements to the display
 show(list)
 
-# We are free to use an extra list and concatenate it while rendering:
-list2 = [
-  Text("something less", fg=WHITE),
-  Text("something more", fg=WHITE),
-]
-show(list + list2)
+# We can concatenate an extra list while rendering:
+show(list + [Text("something less"), Text("something more")])
 
-# Then we display the first list with alternative text
-show(list + [Text("something different", fg=YELLOW)])
-
-# Finally, we modify each of the text list's content and display that
-list2[0].str = "something else"
-show(list + list2)
+# We can also modify elements from that list directly
+list[0].string = "something else"
+show(list)
 ```
 
 ---

--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -163,7 +163,7 @@ display.show(group)
 
 # Create a white polygon with a red outline and print everything. Text on top
 poly = display.Polygon([0, 0, 640, 400, 0, 400], display.WHITE)
-outline = display.Polygon([0, 0, 640, 400, 0, 400], display.RED)
+outline = display.Polyline([0, 0, 640, 400, 0, 400], display.RED)
 display.show(text, line, outline, poly)
 ```
 

--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -34,13 +34,11 @@ import touch
 import display
 
 def change_text(button):
-    display.text(f"Button {button} touched!", 0, 0, 0xffffff)
-    display.show()
+    show([display.Text(f"Button {button} touched!", display.WHITE)])
 
 touch.callback(touch.BOTH, change_text)
 
-display.text("Tap a touch button", 0, 0, 0xffffff)
-display.show()
+display.show([Text("Tap a touch button", display.WHITE)])
 ```
 
 ---
@@ -106,11 +104,11 @@ device.battery_level() # Returns the current battery level as a percentage
 | Members | Description |
 |:--------|:------------|
 | `brightness(level)` **function**             | Sets the display's brightness. `level` can be 0, 1, 2, 3, or 4.
-| `Rect(width, height, color)` **class**       | Rectangle with given width, height and color [1]
-| `Line(width, height, color)` **class**       | Rectangle with given width, height and color [1]
-| `Polygon(list, fill=, stroke=, width=)` **class** | Polygon with given fill and stroke color [1], the shape is defined by a `list` of tuples of `(x, y)` coordinates.
-| `Polyline(list, color, [width])` **class**   | Segmented line with given color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
-| `Text(string, color)`                        | Display the given `string` with the given `color` [1]
+| `Text(string, fg=)` **class**                | Text with the given `string` shown with the given color [1]
+| `Rect(width, height, fg=)` **class**         | Rectangle with given width, height and color [1]
+| `Line(x1, y1, x2, y2, fg=)` **class**        | Line with given coordinates and color [1]
+| `Polygon(list, width=, fg=, bg=)` **class**  | Polygon with given fill and stroke color [1], the shape is defined by a `list` of tuples of `(x, y)` coordinates.
+| `Polyline(list, width=, fg=)` **class**      | Segmented line with given color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
 | `show(list)` **function**                    | Show a list of shapes onto the display.
 | `WIDTH` **constant**                         | The display width in pixels. Equal to 640.
 | `HEIGHT` **constant**                        | The display height in pixels. Equal to 400.
@@ -134,41 +132,45 @@ device.battery_level() # Returns the current battery level as a percentage
 > [1]: The colors are small values that do not cover the full palette of the display.
 > The 16 default values can be one of the constants listed above.
 > There will be an API to customize these colors coming in the future.
+> The default foreground is white and background is gray3.
 
 ```python
 from display import *
 
 # Create a list that will contain all the thing we want to display
-list = []
+list = [
+  # It has a long red horizontal rectangle that we place near the middle
+  Rect(10, 30, fg=RED).move(300, 200),
 
-# It has a long red horizontal rectangle that we place near the middle
-list += Rect(10, 30, RED).move(300, 200)
+  # It has a vertical line with 5 segments doing some zig-zags.
+  Polyline([(10,20), (40,40), (10,60), (40,80), (10,100), (40,120)], fg=RED),
 
-# It has a vertical line with 5 segments doing some zig-zags.
-list += Polyline([(10,20), (40,40), (10,60), (40,80), (10,100), (40,120)], 
+  # It has a triangle filled in yellow, moved to the top right corner.
+  Polygon([(0,0), (10,0), (5,8)], bg=YELLOW).move(WIDTH - 50, HEIGHT - 50),
 
-# It has a triangle filled in yellow, moved to the top right corner.
-list += Polygon([(0,0), (10,0), (5,8)], fill=YELLOW).move(WIDTH - 50, HEIGHT - 50)
+  # It has a diagonal line through the whole display, bottom left to top right
+  Line(0, 0, WIDTH, HEIGHT),
 
-# It has a diagonal line through the whole display, bottom left to top right
-list += Line(WIDTH, HEIGHT, WHITE)
+  # It has a text message in the middle
+  Text("something").move(WIDTH/2, HEIGHT/2),
+]
 
-# If we wish, we can use a separate list, here we store a few text messages
-text = []
-text += Text("something less", WHITE)
-text += Text("something more", WHITE)
+# Render these elements to the display
+show(list)
 
-# Then we display all of that at once
-show(list + text)
+# We are free to use an extra list and concatenate it while rendering:
+list2 = [
+  Text("something less", fg=WHITE),
+  Text("something more", fg=WHITE),
+]
+show(list + list2)
 
-# Then we display the list of geometric shapes with alternative text
-show(list + Text("something different", YELLOW)
+# Then we display the first list with alternative text
+show(list + [Text("something different", fg=YELLOW)])
 
 # Finally, we modify each of the text list's content and display that
-# along with the geometric shapes
-for x in text:
-    text[x].str = "something else"
-show(list + text)
+list2[0].str = "something else"
+show(list + list2)
 ```
 
 ---

--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -105,14 +105,13 @@ device.battery_level() # Returns the current battery level as a percentage
 
 | Members | Description |
 |:--------|:------------|
-| `fill(color)` **function**                   | Fills the entire display with a color. `color` should be a 24-bit RGB value such as `0xAABBCC`.
-| `pixel(x, y, color)` **function** ❌           | Draws a single pixel of color `color` at the position `x`, `y`.
-| `hline(x,y,width,color)` **function**        | Draws a horizontal line from the position `x`, `y`, with a given `width` and `color`.
-| `vline(x,y,height,color)` **function**       | Draws a vertical line from the position `x`, `y`, with a given `height` and `color`.
-| `line(x1,y1,x2,y2,color)` **function**       | Draws a straight line from the position `x1`, `y1`, to the position `x2`, `y2`, with a given `color`.
-| `text("string",x,y,color)`&nbsp;**function** | Draws text at the position `x`, `y`, with a given `color`.
-| `show()` **function**                        | Prints the populated frame buffer to the display. After this call, another series of drawing functions may be called and `show()` can be used to print the next frame. This also clears the display.
 | `brightness(level)` **function**             | Sets the display's brightness. `level` can be 0, 1, 2, 3, or 4.
+| `Rect(width, height, color)` **class**       | Rectangle with given width, height and color [1]
+| `Line(width, height, color)` **class**       | Rectangle with given width, height and color [1]
+| `Polygon(list, fill=, stroke=, width=)` **class** | Polygon with given fill and stroke color [1], the shape is defined by a `list` of tuples of `(x, y)` coordinates.
+| `Polyline(list, [width,])` **class**         | Segmented line with given fill and stroke color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
+| `Text(string, color)`                        | Display the given `string` with the given `color` [1]
+| `show(list)` **function**                    | Show a list of shapes onto the display.
 | `WIDTH` **constant**                         | The display width in pixels. Equal to 640.
 | `HEIGHT` **constant**                        | The display height in pixels. Equal to 400.
 

--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -34,11 +34,13 @@ import touch
 import display
 
 def change_text(button):
-    show([display.Text(f"Button {button} touched!", display.WHITE)])
+    new_text = display.Text(f"Button {button} touched!", display.WHITE)
+    display.show(new_text)
 
 touch.callback(touch.BOTH, change_text)
 
-display.show([Text("Tap a touch button", display.WHITE)])
+initial_text = display.Text("Tap a touch button", display.WHITE)
+display.show(initial_text)
 ```
 
 ---
@@ -99,71 +101,70 @@ device.battery_level() # Returns the current battery level as a percentage
 
 ### `display` – Monocle specific
 
-> The display module allows for drawing to the micro OLED display. An image can be prepared using the functions below, and then `show()` can be used to print the image to the display.
+> The display module allows for drawing to the micro OLED display.
 
 | Members | Description |
 |:--------|:------------|
-| `brightness(level)` **function**             | Sets the display's brightness. `level` can be 0, 1, 2, 3, or 4.
-| `Text(string, color=)` **class**             | Text with the given `string` shown with the given color [1]
-| `Rect(width, height, color=)` **class**      | Rectangle with given width, height and color [1]
-| `Line(x1, y1, x2, y2, color=)` **class**     | Line with given coordinates and color [1]
-| `Polygon(list, width=, stroke=, fill=)` **class** | Polygon with given fill and stroke color [1], the shape is defined by a `list` of tuples of `(x, y)` coordinates.
-| `Polyline(list, width=, color=)` **class**   | Segmented line with given color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
-| `show(list)` **function**                    | Show a list of shapes onto the display.
-| `WIDTH` **constant**                         | The display width in pixels. Equal to 640.
-| `HEIGHT` **constant**                        | The display height in pixels. Equal to 400.
-| `BLACK` **constant**                         | Configurable color, `#000000` by default [1].
-| `RED` **constant**                           | Configurable color, `#ad2323` by default [1].
-| `GREEN` **constant**                         | Configurable color, `#1d6914` by default [1].
-| `BLUE` **constant**                          | Configurable color, `#2a4bd7` by default [1].
-| `CYAN` **constant**                          | Configurable color, `#29d0d0` by default [1].
-| `MAGENTA` **constant**                       | Configurable color, `#8126c0` by default [1].
-| `YELLOW` **constant**                        | Configurable color, `#ffee33` by default [1].
-| `WHITE` **constant**                         | Configurable color, `#ffffff` by default [1].
-| `GRAY1` **constant**                         | Configurable color, `#1c1c1c` by default [1].
-| `GRAY2` **constant**                         | Configurable color, `#383838` by default [1].
-| `GRAY3` **constant**                         | Configurable color, `#555555` by default [1].
-| `GRAY4` **constant**                         | Configurable color, `#717171` by default [1].
-| `GRAY5` **constant**                         | Configurable color, `#8d8d8d` by default [1].
-| `GRAY6` **constant**                         | Configurable color, `#aaaaaa` by default [1].
-| `GRAY7` **constant**                         | Configurable color, `#c6c6c6` by default [1].
-| `GRAY8` **constant**                         | Configurable color, `#e2e2e2` by default [1].
-
-> [1]: The colors are small values that do not cover the full palette of the display.
-> The 16 default values can be one of the constants listed above.
-> There will be an API to customize these colors coming in the future.
-> The default foreground is white and background is gray3.
+| `Text(string, x, y, color, justify=TOP_LEFT)` **class**       | Creates a text object at the coordinate `x, y` which can be passed to `display.show()`. `string` can be any string, and `color` can be any color from the available color palette. If the `justify` parameter is given, the text will be justified accordingly from the `x, y` coordinate.
+| `Rectangle(x1, y1, x2, y2, color)` **class**                  | Creates a rectangle object which can be passed to `display.show()`. `x1, y1` and `x2, y2` define each corner of the rectangle. `color` can be any color from the available color palette.
+| `Line(x1, y1, x2, y2, color, thickness=1)` **class**          | Creates a line object from `x1, y1` to `x2, y2` which can be passed to `display.show()`. `color` can be any color from the available color palette, and `thickness` can optionally be provided to override the default line thickness in pixels.
+| `Polygon([x1, y1, ... xn, yn], color)` **class**              | Creates a polygon object which can be passed to `display.show()`. The first parameter should be a list of coordinates, and `color` can be any color from the available color palette. Polygons are always closed shapes, therefore if the last coordinate does not close the shape, it will be closed automatically.
+| `Polyline([x1,y1,...xn,yn],color,thickness=1)`&nbsp;**class** | Similar to the Polygon object, Polyline creates a shape based on a list of coordinates. Unlike Polygon, Polyline does not need to be a closed shape. `color` can be any color from the available color palette, and `thickness` can optionally be provided to override the default line thickness in pixels.
+| `show(object_1, ... object_n)` **function**                   | Prints to the display. The passed arguments can be any number of Text, Line, Rectangle, Polygon, or Polyline objects, or any number of lists containing such objects. Objects are layered front to back, i.e. `object_1` is shown on top of `object_n`.
+| `move(x, y)` **function**                                     | `move()` can be called as a class method on any printable object to translate its position. `x` and `y` will move the object relative to its current position.
+| `move([objects], x, y)` **function**                          | Additionally, `move()` can be called as a standard function to move a list of objects together. This is useful for grouping printable objects together and moving them as layers.
+| `color(color)` **function**                                   | `color()` can be called as a class method on any printable object to change its color. `color` can be any color from the available color palette.
+| `color([objects], color)` **function**                        | Additionally, `color()` can be called as a standard function to change the color on a whole list of objects. `color` can be any color from the available color palette.
+| `brightness(level)` **function**                              | Sets the display's brightness. `level` can be 0 (dimmest), 1, 2, 3, or 4 (brightest). Level 3 is the default.
+| `CLEAR` **constant**                                          | If using the default color palette, this constant indexes the color `#000000`. Note, color indexes may be overridden by the user.
+| `RED` **constant**                                            | If using the default color palette, this constant indexes the color `#ad2323`. Note, color indexes may be overridden by the user.
+| `GREEN` **constant**                                          | If using the default color palette, this constant indexes the color `#1d6914`. Note, color indexes may be overridden by the user.
+| `BLUE` **constant**                                           | If using the default color palette, this constant indexes the color `#2a4bd7`. Note, color indexes may be overridden by the user.
+| `CYAN` **constant**                                           | If using the default color palette, this constant indexes the color `#29d0d0`. Note, color indexes may be overridden by the user.
+| `MAGENTA` **constant**                                        | If using the default color palette, this constant indexes the color `#8126c0`. Note, color indexes may be overridden by the user.
+| `YELLOW` **constant**                                         | If using the default color palette, this constant indexes the color `#ffee33`. Note, color indexes may be overridden by the user.
+| `WHITE` **constant**                                          | If using the default color palette, this constant indexes the color `#ffffff`. Note, color indexes may be overridden by the user.
+| `GRAY1` **constant**                                          | If using the default color palette, this constant indexes the color `#1c1c1c`. Note, color indexes may be overridden by the user.
+| `GRAY2` **constant**                                          | If using the default color palette, this constant indexes the color `#383838`. Note, color indexes may be overridden by the user.
+| `GRAY3` **constant**                                          | If using the default color palette, this constant indexes the color `#555555`. Note, color indexes may be overridden by the user.
+| `GRAY4` **constant**                                          | If using the default color palette, this constant indexes the color `#717171`. Note, color indexes may be overridden by the user.
+| `GRAY5` **constant**                                          | If using the default color palette, this constant indexes the color `#8d8d8d`. Note, color indexes may be overridden by the user.
+| `GRAY6` **constant**                                          | If using the default color palette, this constant indexes the color `#aaaaaa`. Note, color indexes may be overridden by the user.
+| `GRAY7` **constant**                                          | If using the default color palette, this constant indexes the color `#c6c6c6`. Note, color indexes may be overridden by the user.
+| `GRAY8` **constant**                                          | If using the default color palette, this constant indexes the color `#e2e2e2`. Note, color indexes may be overridden by the user.
+| `TOP_LEFT` **constant**                                       | Justifies a text object on its `x, y` coordinate to the top left.
+| `MIDDLE_LEFT` **constant**                                    | Justifies a text object on its `x, y` coordinate to the middle left
+| `BOTTOM_LEFT` **constant**                                    | Justifies a text object on its `x, y` coordinate to the bottom left
+| `TOP_CENTER` **constant**                                     | Justifies a text object on its `x, y` coordinate to the top center
+| `BOTTOM_CENTER` **constant**                                  | Justifies a text object on its `x, y` coordinate to the middle center
+| `TOP_RIGHT` **constant**                                      | Justifies a text object on its `x, y` coordinate to the bottom center
+| `MIDDLE_CENTER` **constant**                                  | Justifies a text object on its `x, y` coordinate to the top right
+| `MIDDLE_RIGHT` **constant**                                   | Justifies a text object on its `x, y` coordinate to the middle right
+| `BOTTOM_RIGHT` **constant**                                   | Justifies a text object on its `x, y` coordinate to the bottom right
+| `WIDTH` **constant**                                          | The display width in pixels. Equal to 640.
+| `HEIGHT` **constant**                                         | The display height in pixels. Equal to 400.
 
 ```python
-from display import *
+import display
 
-# Create a list that will contain all the thing we want to display
-list = [
-  # It has a text message in the middle
-  Text("something").move(WIDTH//2, HEIGHT//2),
+# Place some text in the middle of the screen with a line underneath
+text = display.Text('Hello world', 320, 200, display.WHITE, justify=display.MIDDLE_CENTER)
+line = display.Line(50, 230, 590, 230, display.WHITE)
+display.show(text, line)
 
-  # It has a long red horizontal rectangle that we place near the middle
-  Rect(100, 30, color=RED).move(300, 200),
+# Group the line and the text together to change the color of both at the same time
+group = [text, line]
+display.color(group, display.GREEN)
+display.show(group)
 
-  # It has a horizontal line with 5 segments doing some zig-zags.
-  Polyline([(100,20), (200,80), (300,20), (400,80), (500,20), (600,80)], color=RED),
+# Move only the line down, and print everything again
+line.move(0, -100)
+display.show(group)
 
-  # It has a triangle filled in yellow, moved to the top right corner.
-  Polygon([(0,0), (100,0), (50,80)], stroke=None, fill=YELLOW).move(50, 100),
-
-  # It has a diagonal line through the whole display, bottom left to top right
-  Line(0, 0, WIDTH - 1, HEIGHT - 1),
-]
-
-# Render these elements to the display
-show(list)
-
-# We can concatenate an extra list while rendering:
-show(list + [Text("something less"), Text("something more")])
-
-# We can also modify elements from that list directly
-list[0].string = "something else"
-show(list)
+# Create a white polygon with a red outline and print everything. Text on top
+poly = display.Polygon([0, 0, 640, 400, 0, 400], display.WHITE)
+outline = display.Polygon([0, 0, 640, 400, 0, 400], display.RED)
+display.show(text, line, outline, poly)
 ```
 
 ---

--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -109,11 +109,67 @@ device.battery_level() # Returns the current battery level as a percentage
 | `Rect(width, height, color)` **class**       | Rectangle with given width, height and color [1]
 | `Line(width, height, color)` **class**       | Rectangle with given width, height and color [1]
 | `Polygon(list, fill=, stroke=, width=)` **class** | Polygon with given fill and stroke color [1], the shape is defined by a `list` of tuples of `(x, y)` coordinates.
-| `Polyline(list, [width,])` **class**         | Segmented line with given fill and stroke color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
+| `Polyline(list, color, [width])` **class**   | Segmented line with given color [1], the segments are defined by a `list` of tuples of `(x, y)` coordinates.
 | `Text(string, color)`                        | Display the given `string` with the given `color` [1]
 | `show(list)` **function**                    | Show a list of shapes onto the display.
 | `WIDTH` **constant**                         | The display width in pixels. Equal to 640.
 | `HEIGHT` **constant**                        | The display height in pixels. Equal to 400.
+| `BLACK` **constant**                         | Configurable color, `#000000` by default [1].
+| `RED` **constant**                           | Configurable color, `#ad2323` by default [1].
+| `GREEN` **constant**                         | Configurable color, `#1d6914` by default [1].
+| `BLUE` **constant**                          | Configurable color, `#2a4bd7` by default [1].
+| `CYAN` **constant**                          | Configurable color, `#29d0d0` by default [1].
+| `MAGENTA` **constant**                       | Configurable color, `#8126c0` by default [1].
+| `YELLOW` **constant**                        | Configurable color, `#ffee33` by default [1].
+| `WHITE` **constant**                         | Configurable color, `#ffffff` by default [1].
+| `GRAY1` **constant**                         | Configurable color, `#1c1c1c` by default [1].
+| `GRAY2` **constant**                         | Configurable color, `#383838` by default [1].
+| `GRAY3` **constant**                         | Configurable color, `#555555` by default [1].
+| `GRAY4` **constant**                         | Configurable color, `#717171` by default [1].
+| `GRAY5` **constant**                         | Configurable color, `#8d8d8d` by default [1].
+| `GRAY6` **constant**                         | Configurable color, `#aaaaaa` by default [1].
+| `GRAY7` **constant**                         | Configurable color, `#c6c6c6` by default [1].
+| `GRAY8` **constant**                         | Configurable color, `#e2e2e2` by default [1].
+
+> [1]: The colors are small values that do not cover the full palette of the display.
+> The 16 default values can be one of the constants listed above.
+> There will be an API to customize these colors coming in the future.
+
+```python
+from display import *
+
+# Create a list that will contain all the thing we want to display
+list = []
+
+# It has a long red horizontal rectangle that we place near the middle
+list += Rect(10, 30, RED).move(300, 200)
+
+# It has a vertical line with 5 segments doing some zig-zags.
+list += Polyline([(10,20), (40,40), (10,60), (40,80), (10,100), (40,120)], 
+
+# It has a triangle filled in yellow, moved to the top right corner.
+list += Polygon([(0,0), (10,0), (5,8)], fill=YELLOW).move(WIDTH - 50, HEIGHT - 50)
+
+# It has a diagonal line through the whole display, bottom left to top right
+list += Line(WIDTH, HEIGHT, WHITE)
+
+# If we wish, we can use a separate list, here we store a few text messages
+text = []
+text += Text("something less", WHITE)
+text += Text("something more", WHITE)
+
+# Then we display all of that at once
+show(list + text)
+
+# Then we display the list of geometric shapes with alternative text
+show(list + Text("something different", YELLOW)
+
+# Finally, we modify each of the text list's content and display that
+# along with the geometric shapes
+for x in text:
+    text[x].str = "something else"
+show(list + text)
+```
 
 ---
 


### PR DESCRIPTION
This also worked with the typo, which is good: easy to have some `args = (...)` then use it for both `Polyline(*args)` and `Polygon(*args)` to have both the outline and the content.