### PR TITLE
Fix the Polyline example

### DIFF
--- a/micropython/micropython.md
+++ b/micropython/micropython.md
@@ -162,8 +162,8 @@ line.move(0, -100)
 display.show(group)
 
 # Create a white polygon with a red outline and print everything again
-poly = display.Polygon([0, 0, 640, 400, 0, 400], display.WHITE)
-outline = display.Polyline([0, 0, 640, 400, 0, 400, 0, 0], display.RED)
+poly = display.Polygon([10, 10, 640-10, 400-10, 10, 400-10], display.GRAY2)
+outline = display.Polyline([10, 10, 640-10, 400-10, 10, 400-10], display.WHITE, thickness=10)
 display.show(text, line, outline, poly)
 ```
 


### PR DESCRIPTION
From the chat:
https://discord.com/channels/963222352534048818/1074358904168923146/1099650588586807296
```
# Create a white polygon with a red outline and print everything again
>>> poly = display.Polygon([0, 0, 640, 400, 0, 400], display.WHITE)
>>> outline = display.Polyline([0, 0, 640, 400, 0, 400, 0, 0], display.RED)
>>> display.show(text, line, outline, poly)
Traceback (most recent call last):
  File "<stdin>", in <module>
  File "display.py", in show
MemoryError: memory allocation failed, allocating 32768 bytes
```

Once fixed, it was also not very visible.